### PR TITLE
v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2] - 2023-07-30
+
+## Added
+
+- The mesh can now be stretched by setting the ``terrain_unit_size``.
+A 1024x1024 size terrain can, using this method, be stretched to 16384x16384 
+while keeping the same amount of geometry as before. It looks rougher though.
+- Ignore ``max_terrain_height`` by setting it to ``-1``
+
+## [0.0.1] - 2023-07-28
+
+### Added
+
+- Project files and REAMDME
+
+[unreleased]: https://github.com/KingMalur/TerrainGenerator/compare/v0.0.2...HEAD
+
+[0.0.2]: https://github.com/KingMalur/TerrainGenerator/releases/tag/v0.0.2
+[0.0.1]: https://github.com/KingMalur/TerrainGenerator/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Godot project can create a chunk based mesh-array with collisions and navig
 It's **not yet ready** to be used in a real project! It's just a fun project of mine to learn mesh generation (I added some explanations as comments for myself, maybe they're helpful for you too).  
 
 ## Usage  
-If you do want to use it in you project, just follow these steps:  
+If you do want to use it in your project, just follow these steps:  
 1) Copy the script ``TerrainGenerator.gd`` and attach it to a ``Node3D``  
 2) Save your scene and then reload the saved scene  
 3) Fill in the exported variables with values you like  
@@ -19,6 +19,7 @@ If you do want to use it in you project, just follow these steps:
 - The same is true for the exported variable ``shader_material`` that's currently used to color the terrain  
 
 ## ToDo  
+- [ ] Add unit size changing <sub><sup>(1u in Godot multiplied by X to stretch the terrain)</sub></sup>
 - [ ] Create a water mesh & shader  
 - [ ] Add signals  
 - [ ] Better shaders <sub><sup>(Urgent! Current shader looks real bad for bigger terrain..)</sup></sub>  

--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ If you do want to use it in your project, just follow these steps:
 - Try to balance the ``noise_height_modifier`` & the ``heightmap_modifier`` when sampling a heightmap  
 - Edit the exported variable ``navigation_mesh`` to adapt it to your requirements  
 - The same is true for the exported variable ``shader_material`` that's currently used to color the terrain  
+- Try to balance the values for ``noise_height_modifier`` & ``max_rock_height`` (in the shader settings) with the ``terrain_unit_size`` <sub><sup>(Multiplying both values with the ``terrain_unit_size`` seems to work pretty good from a bit of testing)<sub><sup>  
 
 ## ToDo  
-- [ ] Add unit size changing <sub><sup>(1u in Godot multiplied by X to stretch the terrain)</sub></sup>
-- [ ] Create a water mesh & shader  
-- [ ] Add signals  
-- [ ] Better shaders <sub><sup>(Urgent! Current shader looks real bad for bigger terrain..)</sup></sub>  
+- [x] Add unit size changing <sub><sup>(1u in Godot multiplied by X to stretch the terrain)<sub><sup>  
 - [ ] Add ``center_terrain`` <sub><sup>(You can set the flag but it's not doing anything..)</sup></sub>  
+- [ ] Add signals  
 - [ ] Add edge falloff by heightmap or by code <sub><sup>(Could take some percentage and check against current x/z position -> Should be faster than sampling another heightmap)</sub></sup>  
+- [ ] Better shaders <sub><sup>(Urgent! Current shader looks real bad for bigger terrain..)</sup></sub>  
+- [ ] Create a water mesh & shader  
+- [ ] Fix shader breaking on window resize  
+- [ ] Add unit tests :see_no_evil:  
 - [ ] ...  

--- a/scenes/mesh_generation.tscn
+++ b/scenes/mesh_generation.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=3 uid="uid://dugu28e7cwvja"]
+[gd_scene load_steps=14 format=3 uid="uid://dugu28e7cwvja"]
 
 [ext_resource type="Shader" path="res://shader/texture_shader.gdshader" id="1_ci1p8"]
 [ext_resource type="Script" path="res://scripts/TerrainGenerator.gd" id="1_rhpy5"]
@@ -18,18 +18,12 @@ fog_light_color = Color(0.517647, 0.552941, 0.607843, 1)
 render_priority = 0
 shader = ExtResource("1_ci1p8")
 shader_parameter/min_grass_height = -0.3
-shader_parameter/max_rock_height = 1.6
+shader_parameter/max_rock_height = 5.0
 shader_parameter/uv_scale = Vector2(1, 1)
 shader_parameter/terrain_grass = ExtResource("2_lnjpc")
 shader_parameter/terrain_rock = ExtResource("3_0a2y6")
 
 [sub_resource type="NavigationMesh" id="NavigationMesh_75yjx"]
-
-[sub_resource type="Shader" id="Shader_ndwq6"]
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_spjjp"]
-render_priority = 0
-shader = SubResource("Shader_ndwq6")
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_0nxe2"]
 albedo_color = Color(0, 0.52549, 0.929412, 1)
@@ -66,7 +60,6 @@ environment = SubResource("Environment_7eydn")
 
 [node name="TerrainGenerator" type="Node3D" parent="."]
 script = ExtResource("1_rhpy5")
-noise_seed = 645507467
 heightmap_tex = ExtResource("3_khby7")
 shader_material = SubResource("ShaderMaterial_nqns2")
 navigation_mesh = SubResource("NavigationMesh_75yjx")
@@ -74,5 +67,4 @@ navigation_mesh = SubResource("NavigationMesh_75yjx")
 [node name="Water" type="MeshInstance3D" parent="."]
 transform = Transform3D(5000, 0, 0, 0, 1, 0, 0, 0, 5000, 0, 0, 0)
 visible = false
-material_override = SubResource("ShaderMaterial_spjjp")
 mesh = SubResource("PlaneMesh_1ytj5")

--- a/scripts/TerrainGenerator.gd
+++ b/scripts/TerrainGenerator.gd
@@ -421,9 +421,19 @@ func _sample_heightmap(y: float, z: float, x: float) -> float:
 		var heightmap_percent_x = x / (terrain_x_size * 1.0)
 		# clamp with (max - 1) to avoid index too high error
 		# -> small inacuracies but not enough to fix completely
-		var heightmap_z = clamp(heightmap_percent_z * heightmap_tex.get_height(), 0, heightmap_tex.get_height() - 1)
-		var heightmap_x = clamp(heightmap_percent_x * heightmap_tex.get_width(), 0, heightmap_tex.get_width() - 1)
-		var heightmap_color = heightmap_tex.get_image().get_pixel(heightmap_x, heightmap_z)
+		var heightmap_z = clamp( \
+			heightmap_percent_z * heightmap_tex.get_height(), \
+			0, \
+			heightmap_tex.get_height() - 1)
+		var heightmap_x = clamp( \
+			heightmap_percent_x * heightmap_tex.get_width(), \
+			0, \
+			heightmap_tex.get_width() - 1)
+		var heightmap_color = heightmap_tex \
+			.get_image() \
+			.get_pixel( \
+				heightmap_x, \
+				heightmap_z)
 		# White equals r=1, b=1, g=1
 		# Add all three together and divide by 3 to get the average
 		heightmap_y = (heightmap_color.r + heightmap_color.g + heightmap_color.b) / 3.0

--- a/scripts/TerrainGenerator.gd
+++ b/scripts/TerrainGenerator.gd
@@ -43,6 +43,7 @@ var _fast_noise_lite: FastNoiseLite
 @export_enum("16:16", "32:32", "64:64") var chunk_size: int = 16
 @export_range(64, 1024, 64) var terrain_x_size: int = 64
 @export_range(64, 1024, 64) var terrain_z_size: int = 64
+## The generated terrains maximum height (Set to -1 to ignore)
 @export var max_terrain_height: float = 10.0
 ## How many substeps should be performed in one/1 "unit of mesh" (1: 1u = 1 side, 4: 1u = 4 sides)
 @export_enum("1:1", "2:2", "4:4") var terrain_resolution: int = 1
@@ -347,7 +348,8 @@ func _generate_chunk(chunk_position: Vector2) -> void:
 							(z_float / terrain_unit_size) * noise_offset \
 						) * noise_height_modifier
 					y = _sample_heightmap(y, z_float, x_float)
-					if y > max_terrain_height:
+					if max_terrain_height != -1 \
+						&& y > max_terrain_height:
 						y = max_terrain_height
 					
 					if y < _terrain_min_height && y != null:


### PR DESCRIPTION
## Added

- The mesh can now be stretched by setting the ``terrain_unit_size``. A 1024x1024 size terrain can, using this method, be stretched to 16384x16384 while keeping the same amount of geometry as before. It looks rougher though.
- Ignore ``max_terrain_height`` by setting it to ``-1``