### PR TITLE
v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - The mesh can now be centered around (0, 0, 0)
+- Easing towards ``max_terrain_height`` for flat regions
 
 ## Changed
 
 - If ``create_on_start`` is active and the scene is run, a new seed get's
-generated instead of using the one set in the editor.
+generated instead of using the one set in the editor
+- Use ``d_ignore_max_terrain_height`` instead of setting it to ``-1``
 
 ## Fixed
 
@@ -26,7 +28,7 @@ generated instead of using the one set in the editor.
 
 - The mesh can now be stretched by setting the ``terrain_unit_size``.
 A 1024x1024 size terrain can, using this method, be stretched to 16384x16384 
-while keeping the same amount of geometry as before. It looks rougher though.
+while keeping the same amount of geometry as before. It looks rougher though
 - Ignore ``max_terrain_height`` by setting it to ``-1``
 
 ## [0.0.1] - 2023-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2023-08-01
+
 ## Added
 
 - The mesh can now be centered around (0, 0, 0)
-- Easing towards ``max_terrain_height`` for flat regions
+- Easing towards ``max_terrain_height`` for flat regions using a curve
+- Easing towards 0 at the edges using ``ease_towards_edge`` and a curve
 
 ## Changed
 
 - If ``create_on_start`` is active and the scene is run, a new seed get's
 generated instead of using the one set in the editor
 - Use ``d_ignore_max_terrain_height`` instead of setting it to ``-1``
+- Changed some default editor values to make generating interesting terrain
+easier when loading the scene
 
 ## Fixed
 
 - Calculate correct UV-positions for chunk-positions greater (0, 0)
+- Sampling of heightmap for values greater than 1 of ``terrain_unit_size``
+
+## Removed
+
+- ``d_draw_spheres`` was removed because it was only useful in the beginning
+of the project and had no real purpose (except crashing Godot) now that I can
+see changes on the mesh without them
 
 ## [0.0.2] - 2023-07-30
 
 ## Added
 
-- The mesh can now be stretched by setting the ``terrain_unit_size``.
+- The mesh can now be stretched by setting the ``terrain_unit_size``
 A 1024x1024 size terrain can, using this method, be stretched to 16384x16384 
 while keeping the same amount of geometry as before. It looks rougher though
 - Ignore ``max_terrain_height`` by setting it to ``-1``
@@ -37,7 +49,8 @@ while keeping the same amount of geometry as before. It looks rougher though
 
 - Project files and REAMDME
 
-[unreleased]: https://github.com/KingMalur/TerrainGenerator/compare/v0.0.2...dev
+[unreleased]: https://github.com/KingMalur/TerrainGenerator/compare/v0.0.3...dev
 
+[0.0.3]: https://github.com/KingMalur/TerrainGenerator/releases/tag/v0.0.3
 [0.0.2]: https://github.com/KingMalur/TerrainGenerator/releases/tag/v0.0.2
 [0.0.1]: https://github.com/KingMalur/TerrainGenerator/releases/tag/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2] - 2023-07-30
+
+## Added
+
+- The mesh can now be stretched by setting the ``terrain_unit_size``.
+A 1024x1024 size terrain can, using this method, be stretched to 16384x16384 
+while keeping the same amount of geometry as before. It looks rougher though.
+- Ignore ``max_terrain_height`` by setting it to ``-1``
+
+## [0.0.1] - 2023-07-28
+
+### Added
+
+- Project files and REAMDME
+
+[unreleased]: https://github.com/KingMalur/TerrainGenerator/compare/v0.0.2...HEAD
+
+[0.0.2]: https://github.com/KingMalur/TerrainGenerator/releases/tag/v0.0.2
+[0.0.1]: https://github.com/KingMalur/TerrainGenerator/releases/tag/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- The mesh can now be centered around (0, 0, 0)
+
+## Changed
+
+- If ``create_on_start`` is active and the scene is run, a new seed get's
+generated instead of using the one set in the editor.
+
+## Fixed
+
+- Calculate correct UV-positions for chunk-positions greater (0, 0)
+
 ## [0.0.2] - 2023-07-30
 
 ## Added
@@ -23,7 +36,7 @@ while keeping the same amount of geometry as before. It looks rougher though.
 
 - Project files and REAMDME
 
-[unreleased]: https://github.com/KingMalur/TerrainGenerator/compare/v0.0.2...HEAD
+[unreleased]: https://github.com/KingMalur/TerrainGenerator/compare/v0.0.2...dev
 
 [0.0.2]: https://github.com/KingMalur/TerrainGenerator/releases/tag/v0.0.2
 [0.0.1]: https://github.com/KingMalur/TerrainGenerator/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ If you do want to use it in your project, just follow these steps:
 ## ToDo  
 - [x] Add unit size changing <sub><sup>(1u in Godot multiplied by X to stretch the terrain)<sub><sup>  
 - [x] Add ``center_terrain`` <sub><sup>~~(You can set the flag but it's not doing anything..)~~</sup></sub>  
-- [ ] Add signals  
+- [x] Add signals  
 - [ ] Add edge falloff by heightmap or by code <sub><sup>(Could take some percentage and check against current x/z position -> Should be faster than sampling another heightmap)</sub></sup>  
 - [ ] Better shaders <sub><sup>(Urgent! Current shader looks real bad for bigger terrain..)</sup></sub>  
 - [ ] Create a water mesh & shader  
 - [ ] Fix shader breaking on window resize  
 - [ ] Add unit tests :see_no_evil:  
+- [ ] Fix navigation regions' weird pattern when increasing ``terrain_unit_size``<sub><sup>(Looks like a 45° top down tile..)</sup></sub>  
 - [ ] ...  

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It's **not yet ready** to be used in a real project! It's just a fun project of 
 If you do want to use it in your project, just follow these steps:  
 1) Copy the script ``TerrainGenerator.gd`` and attach it to a ``Node3D``  
 2) Save your scene and then reload the saved scene  
-3) Fill in the exported variables with values you like  
+3) Fill in the exported variables with values you like (Saved scene's already set up with values I like)  
 4) Hit ``Create New Terrain``, ``Create Water Mesh``, ``Create Collision Mesh`` & ``Create Navigation Region``  
 
 ## Hints  

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Godot project can create a chunk based mesh-array with collisions and navig
 It's **not yet ready** to be used in a real project! It's just a fun project of mine to learn mesh generation (I added some explanations as comments for myself, maybe they're helpful for you too).  
 
 ## Usage  
-If you do want to use it in you project, just follow these steps:  
+If you do want to use it in your project, just follow these steps:  
 1) Copy the script ``TerrainGenerator.gd`` and attach it to a ``Node3D``  
 2) Save your scene and then reload the saved scene  
 3) Fill in the exported variables with values you like  
@@ -19,6 +19,7 @@ If you do want to use it in you project, just follow these steps:
 - The same is true for the exported variable ``shader_material`` that's currently used to color the terrain  
 
 ## ToDo  
+- [ ] Add unit size changing <sub><sup>(1u in Godot multiplied by X to stretch the terrain)</sub></sup>
 - [ ] Create a water mesh & shader  
 - [ ] Add signals  
 - [ ] Better shaders <sub><sup>(Urgent! Current shader looks real bad for bigger terrain..)</sup></sub>  

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ If you do want to use it in your project, just follow these steps:
 - [x] Add unit size changing <sub><sup>(1u in Godot multiplied by X to stretch the terrain)<sub><sup>  
 - [x] Add ``center_terrain`` <sub><sup>~~(You can set the flag but it's not doing anything..)~~</sup></sub>  
 - [x] Add signals  
-- [ ] Add edge falloff by heightmap or by code <sub><sup>(Could take some percentage and check against current x/z position -> Should be faster than sampling another heightmap)</sub></sup>  
-- [ ] Better shaders <sub><sup>(Urgent! Current shader looks real bad for bigger terrain..)</sup></sub>  
+- [x] Add edge falloff ~~by heightmap or~~ by code <sub><sup>(Could take some percentage and check against current x/z position -> Should be faster ~~than sampling another heightmap~~)</sub></sup>  
+- [x] Better shaders <sub><sup>(~~Urgent! Current shader looks real bad for bigger terrain..~~ UV-Positions were all over the place..)</sup></sub>  
+- [ ] Fix scene not starting anymore :angry:  
 - [ ] Create a water mesh & shader  
 - [ ] Fix shader breaking on window resize  
 - [ ] Add unit tests :see_no_evil:  

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you do want to use it in your project, just follow these steps:
 
 ## ToDo  
 - [x] Add unit size changing <sub><sup>(1u in Godot multiplied by X to stretch the terrain)<sub><sup>  
-- [ ] Add ``center_terrain`` <sub><sup>(You can set the flag but it's not doing anything..)</sup></sub>  
+- [x] Add ``center_terrain`` <sub><sup>~~(You can set the flag but it's not doing anything..)~~</sup></sub>  
 - [ ] Add signals  
 - [ ] Add edge falloff by heightmap or by code <sub><sup>(Could take some percentage and check against current x/z position -> Should be faster than sampling another heightmap)</sub></sup>  
 - [ ] Better shaders <sub><sup>(Urgent! Current shader looks real bad for bigger terrain..)</sup></sub>  

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ If you do want to use it in your project, just follow these steps:
 ## ToDo  
 - [x] Add unit size changing <sub><sup>(1u in Godot multiplied by X to stretch the terrain)<sub><sup>  
 - [x] Add ``center_terrain`` <sub><sup>~~(You can set the flag but it's not doing anything..)~~</sup></sub>  
-- [ ] Add ``center_terrain`` <sub><sup>(You can set the flag but it's not doing anything..)</sup></sub>  
 - [ ] Add signals  
 - [ ] Add edge falloff by heightmap or by code <sub><sup>(Could take some percentage and check against current x/z position -> Should be faster than sampling another heightmap)</sub></sup>  
 - [ ] Better shaders <sub><sup>(Urgent! Current shader looks real bad for bigger terrain..)</sup></sub>  

--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ If you do want to use it in your project, just follow these steps:
 - Try to balance the ``noise_height_modifier`` & the ``heightmap_modifier`` when sampling a heightmap  
 - Edit the exported variable ``navigation_mesh`` to adapt it to your requirements  
 - The same is true for the exported variable ``shader_material`` that's currently used to color the terrain  
+- Try to balance the values for ``noise_height_modifier`` & ``max_rock_height`` (in the shader settings) with the ``terrain_unit_size`` <sub><sup>(Multiplying both values with the ``terrain_unit_size`` seems to work pretty good from a bit of testing)<sub><sup>  
 
 ## ToDo  
-- [ ] Add unit size changing <sub><sup>(1u in Godot multiplied by X to stretch the terrain)</sub></sup>
-- [ ] Create a water mesh & shader  
-- [ ] Add signals  
-- [ ] Better shaders <sub><sup>(Urgent! Current shader looks real bad for bigger terrain..)</sup></sub>  
+- [x] Add unit size changing <sub><sup>(1u in Godot multiplied by X to stretch the terrain)<sub><sup>  
 - [ ] Add ``center_terrain`` <sub><sup>(You can set the flag but it's not doing anything..)</sup></sub>  
+- [ ] Add signals  
 - [ ] Add edge falloff by heightmap or by code <sub><sup>(Could take some percentage and check against current x/z position -> Should be faster than sampling another heightmap)</sub></sup>  
+- [ ] Better shaders <sub><sup>(Urgent! Current shader looks real bad for bigger terrain..)</sup></sub>  
+- [ ] Create a water mesh & shader  
+- [ ] Fix shader breaking on window resize  
+- [ ] Add unit tests :see_no_evil:  
 - [ ] ...  

--- a/scenes/mesh_generation.tscn
+++ b/scenes/mesh_generation.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=3 uid="uid://dugu28e7cwvja"]
+[gd_scene load_steps=14 format=3 uid="uid://dugu28e7cwvja"]
 
 [ext_resource type="Shader" path="res://shader/texture_shader.gdshader" id="1_ci1p8"]
 [ext_resource type="Script" path="res://scripts/TerrainGenerator.gd" id="1_rhpy5"]
@@ -18,18 +18,12 @@ fog_light_color = Color(0.517647, 0.552941, 0.607843, 1)
 render_priority = 0
 shader = ExtResource("1_ci1p8")
 shader_parameter/min_grass_height = -0.3
-shader_parameter/max_rock_height = 1.6
+shader_parameter/max_rock_height = 5.0
 shader_parameter/uv_scale = Vector2(1, 1)
 shader_parameter/terrain_grass = ExtResource("2_lnjpc")
 shader_parameter/terrain_rock = ExtResource("3_0a2y6")
 
 [sub_resource type="NavigationMesh" id="NavigationMesh_75yjx"]
-
-[sub_resource type="Shader" id="Shader_ndwq6"]
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_spjjp"]
-render_priority = 0
-shader = SubResource("Shader_ndwq6")
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_0nxe2"]
 albedo_color = Color(0, 0.52549, 0.929412, 1)
@@ -66,7 +60,6 @@ environment = SubResource("Environment_7eydn")
 
 [node name="TerrainGenerator" type="Node3D" parent="."]
 script = ExtResource("1_rhpy5")
-noise_seed = 645507467
 heightmap_tex = ExtResource("3_khby7")
 shader_material = SubResource("ShaderMaterial_nqns2")
 navigation_mesh = SubResource("NavigationMesh_75yjx")
@@ -74,5 +67,4 @@ navigation_mesh = SubResource("NavigationMesh_75yjx")
 [node name="Water" type="MeshInstance3D" parent="."]
 transform = Transform3D(5000, 0, 0, 0, 1, 0, 0, 0, 5000, 0, 0, 0)
 visible = false
-material_override = SubResource("ShaderMaterial_spjjp")
 mesh = SubResource("PlaneMesh_1ytj5")

--- a/scenes/mesh_generation.tscn
+++ b/scenes/mesh_generation.tscn
@@ -70,8 +70,8 @@ environment = SubResource("Environment_7eydn")
 
 [node name="TerrainGenerator" type="Node3D" parent="."]
 script = ExtResource("1_rhpy5")
-d_create_on_start = true
 d_print_values = true
+generate_terrain_on_new_seed = false
 noise_height_modifier = 80.0
 center_terrain = true
 terrain_x_size = 256

--- a/scenes/mesh_generation.tscn
+++ b/scenes/mesh_generation.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://dugu28e7cwvja"]
+[gd_scene load_steps=16 format=3 uid="uid://dugu28e7cwvja"]
 
 [ext_resource type="Shader" path="res://shader/texture_shader.gdshader" id="1_ci1p8"]
 [ext_resource type="Script" path="res://scripts/TerrainGenerator.gd" id="1_rhpy5"]
@@ -13,6 +13,15 @@
 
 [sub_resource type="Environment" id="Environment_7eydn"]
 fog_light_color = Color(0.517647, 0.552941, 0.607843, 1)
+
+[sub_resource type="Curve" id="Curve_mgrmx"]
+_data = [Vector2(0, 0), 0.0, 2.87652, 0, 0, Vector2(1, 1), 0.0, 0.0, 0, 0]
+point_count = 2
+
+[sub_resource type="Curve" id="Curve_tllk2"]
+bake_resolution = 512
+_data = [Vector2(0, 1), 0.0, 0.0, 0, 0, Vector2(0, 1), 0.0, 0.0, 0, 0, Vector2(0.702041, 1), 0.0, 0.0, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
+point_count = 4
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_nqns2"]
 render_priority = 0
@@ -60,6 +69,10 @@ environment = SubResource("Environment_7eydn")
 
 [node name="TerrainGenerator" type="Node3D" parent="."]
 script = ExtResource("1_rhpy5")
+ease_towards_max_terrain_height = true
+easing_curve_max_terrain_height = SubResource("Curve_mgrmx")
+ease_towards_edge = true
+easing_curve_edge = SubResource("Curve_tllk2")
 heightmap_tex = ExtResource("3_khby7")
 shader_material = SubResource("ShaderMaterial_nqns2")
 navigation_mesh = SubResource("NavigationMesh_75yjx")

--- a/scenes/mesh_generation.tscn
+++ b/scenes/mesh_generation.tscn
@@ -27,7 +27,7 @@ point_count = 4
 render_priority = 0
 shader = ExtResource("1_ci1p8")
 shader_parameter/min_grass_height = -0.3
-shader_parameter/max_rock_height = 5.0
+shader_parameter/max_rock_height = 60.0
 shader_parameter/uv_scale = Vector2(1, 1)
 shader_parameter/terrain_grass = ExtResource("2_lnjpc")
 shader_parameter/terrain_rock = ExtResource("3_0a2y6")
@@ -39,7 +39,8 @@ albedo_color = Color(0, 0.52549, 0.929412, 1)
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_1ytj5"]
 material = SubResource("StandardMaterial3D_0nxe2")
-size = Vector2(1, 1)
+size = Vector2(1024, 1024)
+subdivide_depth = 10
 
 [node name="MeshGeneration" type="Node3D"]
 
@@ -69,15 +70,25 @@ environment = SubResource("Environment_7eydn")
 
 [node name="TerrainGenerator" type="Node3D" parent="."]
 script = ExtResource("1_rhpy5")
+d_create_on_start = true
+d_print_values = true
+noise_height_modifier = 80.0
+center_terrain = true
+terrain_x_size = 256
+terrain_z_size = 256
+terrain_unit_size = 4
+max_terrain_height = 60.0
 ease_towards_max_terrain_height = true
 easing_curve_max_terrain_height = SubResource("Curve_mgrmx")
 ease_towards_edge = true
 easing_curve_edge = SubResource("Curve_tllk2")
+sample_heightmap = true
+heightmap_modifier = 25.0
 heightmap_tex = ExtResource("3_khby7")
 shader_material = SubResource("ShaderMaterial_nqns2")
 navigation_mesh = SubResource("NavigationMesh_75yjx")
 
 [node name="Water" type="MeshInstance3D" parent="."]
-transform = Transform3D(5000, 0, 0, 0, 1, 0, 0, 0, 5000, 0, 0, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4, 0)
 visible = false
 mesh = SubResource("PlaneMesh_1ytj5")

--- a/scripts/TerrainGenerator.gd
+++ b/scripts/TerrainGenerator.gd
@@ -421,9 +421,19 @@ func _sample_heightmap(y: float, z: float, x: float) -> float:
 		var heightmap_percent_x = x / (terrain_x_size * 1.0)
 		# clamp with (max - 1) to avoid index too high error
 		# -> small inacuracies but not enough to fix completely
-		var heightmap_z = clamp(heightmap_percent_z * heightmap_tex.get_height(), 0, heightmap_tex.get_height() - 1)
-		var heightmap_x = clamp(heightmap_percent_x * heightmap_tex.get_width(), 0, heightmap_tex.get_width() - 1)
-		var heightmap_color = heightmap_tex.get_image().get_pixel(heightmap_x, heightmap_z)
+		var heightmap_z = clamp( \
+			heightmap_percent_z * heightmap_tex.get_height(), \
+			0, \
+			heightmap_tex.get_height() - 1)
+		var heightmap_x = clamp( \
+			heightmap_percent_x * heightmap_tex.get_width(), \
+			0, \
+			heightmap_tex.get_width() - 1)
+		var heightmap_color = heightmap_tex \
+			.get_image() \
+			.get_pixel( \
+				heightmap_x, \
+				heightmap_z)
 		# White equals r=1, b=1, g=1
 		# Add all three together and divide by 3 to get the average
 		heightmap_y = (heightmap_color.r + heightmap_color.g + heightmap_color.b) / 3.0

--- a/scripts/TerrainGenerator.gd
+++ b/scripts/TerrainGenerator.gd
@@ -7,6 +7,11 @@ extends Node3D
 ## Generates a chunked mesh-array based terrain.
 ## Can also create a navigation meshes and collision shapes based on that terrain.
 
+signal terrain_generated
+signal water_mesh_generated
+signal collision_mesh_generated
+signal navigation_regions_generated
+
 const CENTER_OFFSET: float = 0.5
 
 @export_category("DEBUG")
@@ -116,6 +121,7 @@ func _create_new_terrain(new_value: bool = false) -> void:
 	_delete_all()
 	_generate_terrain()
 	
+	terrain_generated.emit()
 	_stop_timer()
 	
 	create_new_terrain = false
@@ -154,6 +160,7 @@ func _create_collision_mesh(new_value: bool = false) -> void:
 		
 		count += 1
 	
+	collision_mesh_generated.emit()
 	_stop_timer()
 	
 	create_collision_mesh = false
@@ -207,6 +214,7 @@ func _create_navigation_region(new_value: bool = false) -> void:
 		# For naming in scene tree
 		count += 1
 	
+	navigation_regions_generated.emit()
 	_stop_timer()
 	
 	create_navigation_region = false
@@ -231,6 +239,7 @@ func _create_water_mesh(new_value: bool = false) -> void:
 	# Needs to look through the chunks and find a good base water level
 	# If navigation is already created -> recreate the navigation meshes
 	
+	water_mesh_generated.emit()
 	_stop_timer()
 	
 	_water_mesh_created = true

--- a/scripts/TerrainGenerator.gd
+++ b/scripts/TerrainGenerator.gd
@@ -80,8 +80,11 @@ var _stop_time: int = 0
 
 func _ready() -> void:
 	if d_create_on_start:
+		# To get some information about the generated mesh at runtime
+		d_print_values = true
 		# To avoid a re-creation of the terrain
 		generate_terrain_on_new_seed = false
+		_generate_new_seed()
 		_create_new_terrain()
 		_create_water_mesh()
 		_create_navigation_region()

--- a/scripts/TerrainGenerator.gd
+++ b/scripts/TerrainGenerator.gd
@@ -370,8 +370,8 @@ func _generate_chunk(chunk_position: Vector2) -> void:
 						z_vertex -= terrain_z_size * terrain_unit_size * CENTER_OFFSET
 					
 					var uv = Vector2()
-					uv.x = inverse_lerp(0, chunk_size, x_float)
-					uv.y = inverse_lerp(0, chunk_size, z_float)
+					uv.x = inverse_lerp(chunk_start_x, chunk_max_x, x_float)
+					uv.y = inverse_lerp(chunk_start_z, chunk_max_z, z_float)
 					
 					surface_tool.set_uv(uv)
 					if d_print_granular_values: print("UV at %s" % uv)

--- a/scripts/TerrainGenerator.gd
+++ b/scripts/TerrainGenerator.gd
@@ -363,6 +363,12 @@ func _generate_chunk(chunk_position: Vector2) -> void:
 					if y > _terrain_max_height && y != null:
 						_terrain_max_height = y
 					
+					var x_vertex: float = x_float
+					var z_vertex: float = z_float
+					if center_terrain:
+						x_vertex -= terrain_x_size * terrain_unit_size * CENTER_OFFSET
+						z_vertex -= terrain_z_size * terrain_unit_size * CENTER_OFFSET
+					
 					var uv = Vector2()
 					uv.x = inverse_lerp(0, chunk_size, x_float)
 					uv.y = inverse_lerp(0, chunk_size, z_float)
@@ -370,7 +376,7 @@ func _generate_chunk(chunk_position: Vector2) -> void:
 					surface_tool.set_uv(uv)
 					if d_print_granular_values: print("UV at %s" % uv)
 					
-					var vertex = Vector3(x_float, y, z_float)
+					var vertex = Vector3(x_vertex, y, z_vertex)
 					surface_tool.add_vertex(vertex)
 					if d_print_granular_values: print("Vertex at %s" % vertex)
 					if d_draw_spheres: _debug_draw_sphere(vertex, sphere_count)

--- a/scripts/TerrainGenerator.gd
+++ b/scripts/TerrainGenerator.gd
@@ -23,8 +23,6 @@ const CENTER_OFFSET: float = 0.5
 @export var d_print_values: bool = false
 ## Prints out vertex-/uv-positions, etc. (can fill up the print queue!)
 @export var d_print_granular_values: bool = false
-## CAUTION: Takes a lot of time & RAM if used for big maps (64x64 should be max!)
-@export var d_draw_spheres: bool = false
 ## Ignores the max_terrain_height setting
 @export var d_ignore_max_terrain_height: bool = false
 
@@ -350,7 +348,6 @@ func _generate_chunk(chunk_position: Vector2) -> void:
 	
 	surface_tool.begin(Mesh.PRIMITIVE_TRIANGLES)
 	
-	var sphere_count = 0
 	for z in range(chunk_start_z, chunk_max_z + 1, terrain_unit_size):
 		# TERRAIN RESOLUTION EXPLANATION
 		# Steps for res: 1
@@ -393,9 +390,7 @@ func _generate_chunk(chunk_position: Vector2) -> void:
 					var vertex = Vector3(x_vertex, y, z_vertex)
 					surface_tool.add_vertex(vertex)
 					if d_print_granular_values: print("Vertex at %s" % vertex)
-					if d_draw_spheres: _debug_draw_sphere(vertex, sphere_count)
 					x_float += 1.0 / (terrain_resolution * 1.0)
-					sphere_count += 1
 #				while x_float < (x + 1) * 1.0:
 			z_float += 1.0 / (terrain_resolution * 1.0)
 #			for x in range(chunk_start_x, chunk_max_x + 1):
@@ -492,16 +487,6 @@ func _apply_max_terrain_height(y: float) -> float:
 	return y
 
 
-func _debug_draw_sphere(pos: Vector3, sphere_count: int) -> void:
-	var ins := MeshInstance3D.new()
-	add_child(ins)
-	ins.name = "Sphere #%s" % sphere_count
-	ins.set_owner(get_tree().edited_scene_root)
-	ins.position = pos
-	var sphere := SphereMesh.new()
-	sphere.radius = 0.1
-	sphere.height = 0.2
-	ins.mesh = sphere
 
 
 func _start_timer() -> void:

--- a/scripts/TerrainGenerator.gd
+++ b/scripts/TerrainGenerator.gd
@@ -83,6 +83,8 @@ var _fast_noise_lite: FastNoiseLite
 
 var _water_mesh_created: bool = false
 
+var _is_editor: bool = OS.has_feature("editor")
+
 var _start_time: int = 0
 var _stop_time: int = 0
 
@@ -150,13 +152,15 @@ func _create_collision_mesh(new_value: bool = false) -> void:
 		var tmp_collision_mesh_base_name = collision_mesh_base_name + "%s"
 		static_body.name = tmp_collision_mesh_base_name % count
 		add_child(static_body)
-		static_body.set_owner(get_tree().edited_scene_root)
+		if _is_editor:
+			static_body.set_owner(get_tree().edited_scene_root)
 		# Create collision_shape and add as child of static_body
 		var collision_shape = CollisionShape3D.new()
 		var tmp_collision_shape_name = collision_shape_base_name + "%s"
 		collision_shape.name = tmp_collision_shape_name % count
 		static_body.add_child(collision_shape)
-		collision_shape.set_owner(get_tree().edited_scene_root)
+		if _is_editor:
+			collision_shape.set_owner(get_tree().edited_scene_root)
 		
 		# Create collision_shape
 		var mesh: Mesh = child.mesh
@@ -198,11 +202,13 @@ func _create_navigation_region(new_value: bool = false) -> void:
 		var tmp_navigation_region_base_name = navigation_region_base_name + "%s"
 		navigation_region.name = tmp_navigation_region_base_name % count
 		add_child(navigation_region)
-		navigation_region.set_owner(get_tree().edited_scene_root)
+		if _is_editor:
+			navigation_region.set_owner(get_tree().edited_scene_root)
 		
 		# Reparent chunk-child to navigation_region
 		child.reparent(navigation_region)
-		child.set_owner(get_tree().edited_scene_root)
+		if _is_editor:
+			child.set_owner(get_tree().edited_scene_root)
 		
 		# TODO: Check for water mesh and eliminate all vertexes below water level
 		if _water_mesh_created:
@@ -214,7 +220,8 @@ func _create_navigation_region(new_value: bool = false) -> void:
 		# Reparent chunk-child to TerrainGenerator-node
 		# -> Easier for later manipulation (just loop through children)
 		child.reparent(self)
-		child.set_owner(get_tree().edited_scene_root)
+		if _is_editor:
+			child.set_owner(get_tree().edited_scene_root)
 		
 		# For naming in scene tree
 		count += 1
@@ -424,7 +431,8 @@ func _generate_chunk(chunk_position: Vector2) -> void:
 	chunk.name = chunk_name
 	
 	add_child(chunk)
-	chunk.set_owner(get_tree().edited_scene_root)
+	if _is_editor:
+		chunk.set_owner(get_tree().edited_scene_root)
 	_update_shader(chunk)
 
 

--- a/scripts/TerrainGenerator.gd
+++ b/scripts/TerrainGenerator.gd
@@ -27,7 +27,6 @@ const CENTER_OFFSET: float = 0.5
 @export var create_navigation_region: bool = false: set = _create_navigation_region
 
 @export_category("Noise Configuration")
-var _fast_noise_lite: FastNoiseLite
 @export var noise_seed: int = 0: set = _apply_noise_seed
 @export var generate_new_seed: bool = false: set = _generate_new_seed
 @export var generate_terrain_on_new_seed: bool = true
@@ -68,11 +67,15 @@ var _fast_noise_lite: FastNoiseLite
 @export var shader_material: ShaderMaterial
 @export var navigation_mesh: NavigationMesh
 
+var _fast_noise_lite: FastNoiseLite
+
+var _water_mesh_created: bool = false
+
 var _terrain_min_height: float = 0.0
 var _terrain_max_height: float = 1.0
+
 var _start_time: int = 0
 var _stop_time: int = 0
-var _water_mesh_created: bool = false
 
 
 func _ready() -> void:

--- a/scripts/TerrainGenerator.gd
+++ b/scripts/TerrainGenerator.gd
@@ -17,6 +17,8 @@ const CENTER_OFFSET: float = 0.5
 @export_category("DEBUG")
 ## Creates a base mesh, collisions, nav-mesh & water at start of the scene
 @export var d_create_on_start: bool = false
+## Always create a new seed on start
+@export var d_new_seed_on_start: bool = false
 ## Prints out various information like chunk-size, chunk-positions, etc.
 @export var d_print_values: bool = false
 ## Prints out vertex-/uv-positions, etc. (can fill up the print queue!)
@@ -89,7 +91,8 @@ func _ready() -> void:
 		d_print_values = true
 		# To avoid a re-creation of the terrain
 		generate_terrain_on_new_seed = false
-		_generate_new_seed()
+		if d_new_seed_on_start:
+			_generate_new_seed()
 		_create_new_terrain()
 		_create_water_mesh()
 		_create_navigation_region()

--- a/scripts/TerrainGenerator.gd
+++ b/scripts/TerrainGenerator.gd
@@ -84,9 +84,6 @@ var _fast_noise_lite: FastNoiseLite
 
 var _water_mesh_created: bool = false
 
-var _terrain_min_height: float = 0.0
-var _terrain_max_height: float = 1.0
-
 var _start_time: int = 0
 var _stop_time: int = 0
 
@@ -331,9 +328,8 @@ func _update_shader(mesh_instance: MeshInstance3D) -> void:
 		return
 	
 	mesh_instance.material_override = shader_material
-	var mat = mesh_instance.get_active_material(0)
-	mat.set_shader_parameter("min_height", _terrain_min_height)
-	mat.set_shader_parameter("max_height", _terrain_max_height)
+	# TODO: Test automatic setting of rock_height, etc.
+	# var mat = mesh_instance.get_active_material(0)
 
 
 func _generate_chunk(chunk_position: Vector2) -> void:
@@ -478,11 +474,6 @@ func _apply_max_terrain_height(y: float) -> float:
 			if y > max_terrain_height:
 				y = max_terrain_height
 	
-	# Apply min & max height for shader
-	if y < _terrain_min_height && y != null:
-		_terrain_min_height = y
-	if y > _terrain_max_height && y != null:
-		_terrain_max_height = y
 	
 	return y
 

--- a/scripts/TerrainGenerator.gd
+++ b/scripts/TerrainGenerator.gd
@@ -43,6 +43,7 @@ var _fast_noise_lite: FastNoiseLite
 @export_enum("16:16", "32:32", "64:64") var chunk_size: int = 16
 @export_range(64, 1024, 64) var terrain_x_size: int = 64
 @export_range(64, 1024, 64) var terrain_z_size: int = 64
+## The generated terrains maximum height (Set to -1 to ignore)
 @export var max_terrain_height: float = 10.0
 ## How many substeps should be performed in one/1 "unit of mesh" (1: 1u = 1 side, 4: 1u = 4 sides)
 @export_enum("1:1", "2:2", "4:4") var terrain_resolution: int = 1
@@ -347,7 +348,8 @@ func _generate_chunk(chunk_position: Vector2) -> void:
 							(z_float / terrain_unit_size) * noise_offset \
 						) * noise_height_modifier
 					y = _sample_heightmap(y, z_float, x_float)
-					if y > max_terrain_height:
+					if max_terrain_height != -1 \
+						&& y > max_terrain_height:
 						y = max_terrain_height
 					
 					if y < _terrain_min_height && y != null:


### PR DESCRIPTION
## Added

- The mesh can now be centered around (0, 0, 0)
- Easing towards ``max_terrain_height`` for flat regions using a curve
- Easing towards 0 at the edges using ``ease_towards_edge`` and a curve

## Changed

- If ``create_on_start`` is active and the scene is run, a new seed get's
generated instead of using the one set in the editor
- Use ``d_ignore_max_terrain_height`` instead of setting it to ``-1``
- Changed some default editor values to make generating interesting terrain
easier when loading the scene

## Fixed

- Calculate correct UV-positions for chunk-positions greater (0, 0)
- Sampling of heightmap for values greater than 1 of ``terrain_unit_size``

## Removed

- ``d_draw_spheres`` was removed because it was only useful in the beginning
of the project and had no real purpose (except crashing Godot) now that I can
see changes on the mesh without them